### PR TITLE
Use default comparer for sorting supports in DiscreteHistogram

### DIFF
--- a/Probability/Extensions.cs
+++ b/Probability/Extensions.cs
@@ -38,7 +38,7 @@ namespace Probability
             int labelMax = dict.Keys
                 .Select(x => x.ToString().Length)
                 .Max();
-            var sup = dict.Keys.OrderBy(k => k).ToList();
+            var sup = dict.Keys.OrderBy(k => k as IComparable ?? ToLabel(k)).ToList();
             int max = dict.Values.Max();
             double scale = max < width ? 1.0 : ((double)width) / max;
             return sup.Select(s => $"{ToLabel(s)}|{Bar(s)}").NewlineSeparated();

--- a/Probability/Extensions.cs
+++ b/Probability/Extensions.cs
@@ -38,7 +38,7 @@ namespace Probability
             int labelMax = dict.Keys
                 .Select(x => x.ToString().Length)
                 .Max();
-            var sup = dict.Keys.OrderBy(ToLabel).ToList();
+            var sup = dict.Keys.OrderBy(k => k).ToList();
             int max = dict.Values.Max();
             double scale = max < width ? 1.0 : ((double)width) / max;
             return sup.Select(s => $"{ToLabel(s)}|{Bar(s)}").NewlineSeparated();


### PR DESCRIPTION
This is for example relevant for StandardDiscreteUniform, which changes from

```
 0|***************************************
 1|***************************************
 2|**************************************
 3|***************************************
-1|***************************************
-2|***************************************
-3|****************************************
```

to

```
-3|****************************************
-2|***************************************
-1|***************************************
 0|***************************************
 1|**************************************
 2|***************************************
 3|**************************************
```