### PR TITLE
Update Projected.cs

### DIFF
--- a/Probability/Projected.cs
+++ b/Probability/Projected.cs
@@ -14,8 +14,10 @@ namespace Probability
           Func<A, R> projection)
         {
             var result = new Projected<A, R>(underlying, projection);
-            if (result.Support().Count() == 1)
-                return Singleton<R>.Distribution(result.Support().First());
+            var support = result.Support().ToList();
+
+            if (support.Count() == 1)
+                return Singleton<R>.Distribution(support.Single());
             return result;
         }
         private Projected(


### PR DESCRIPTION
Cached the value of `result.Support()` in method `Distribution` and changed call to `.First()` to a call to `.Single()` since we know there's only one element in `support` and it better declares intent.